### PR TITLE
qemu_irqs are level triggered

### DIFF
--- a/hw/riscv/sifive_plic.c
+++ b/hw/riscv/sifive_plic.c
@@ -479,7 +479,8 @@ static void parse_hart_config(SiFivePLICState *plic)
 static void sifive_plic_irq_request(void *opaque, int irq, int level)
 {
     SiFivePLICState *plic = opaque;
-    sifive_plic_raise_irq(plic, irq);
+    if (level > 0)
+        sifive_plic_raise_irq(plic, irq);
 }
 
 static void sifive_plic_realize(DeviceState *dev, Error **errp)


### PR DESCRIPTION
Don't raise a PLIC interrupt when QEMU attempts to clear an interrupt by
writing 0 to the level.  I'm not sure if there's a threshold somewhere,
as the VirtIO driver just sets this to 1 or 0.